### PR TITLE
Force Monday-first layout in date pickers for English locale

### DIFF
--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -8,6 +8,7 @@ import 'package:xfin/l10n/app_localizations.dart';
 
 import 'package:xfin/database/app_database.dart';
 import 'package:xfin/utils/db_backup.dart';
+import 'package:xfin/utils/date_picker_locale.dart';
 import 'package:xfin/utils/format.dart';
 
 import 'package:xfin/utils/global_constants.dart';
@@ -80,6 +81,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     final now = DateTime.now();
     final picked = await showDatePicker(
       context: context,
+      locale: resolveDatePickerLocale(Localizations.localeOf(context)),
       initialDate: _startDate ?? now,
       firstDate: DateTime(1900),
       lastDate: DateTime(now.year + 10),
@@ -100,6 +102,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     final now = DateTime.now();
     final picked = await showDatePicker(
       context: context,
+      locale: resolveDatePickerLocale(Localizations.localeOf(context)),
       initialDate: _endDate ?? now,
       firstDate: DateTime(1900),
       lastDate: DateTime(now.year + 10),

--- a/lib/utils/date_picker_locale.dart
+++ b/lib/utils/date_picker_locale.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+/// Keeps the date picker calendar grid Monday-first for all supported languages.
+Locale resolveDatePickerLocale(Locale appLocale) {
+  if (appLocale.languageCode == 'en') {
+    return const Locale('en', 'GB');
+  }
+  return appLocale;
+}
+

--- a/lib/widgets/form_fields.dart
+++ b/lib/widgets/form_fields.dart
@@ -5,6 +5,7 @@ import 'package:xfin/utils/format.dart';
 import '../database/app_database.dart';
 import '../database/tables.dart';
 import '../providers/base_currency_provider.dart';
+import '../utils/date_picker_locale.dart';
 import '../utils/global_constants.dart';
 import '../utils/validators.dart';
 
@@ -28,10 +29,12 @@ class FormFields {
   }) {
     Future<void> pickDate() async {
       final picked = await showDatePicker(
-          context: _context,
-          initialDate: date,
-          firstDate: DateTime(2000),
-          lastDate: DateTime(2101));
+        context: _context,
+        locale: resolveDatePickerLocale(Localizations.localeOf(_context)),
+        initialDate: date,
+        firstDate: DateTime(2000),
+        lastDate: DateTime(2101),
+      );
       if (picked == null || picked == date) return;
       dateController.text = dateFormat.format(picked);
       onDateChanged(picked);

--- a/lib/widgets/trade_form.dart
+++ b/lib/widgets/trade_form.dart
@@ -9,6 +9,7 @@ import 'package:xfin/l10n/app_localizations.dart';
 import '../providers/base_currency_provider.dart';
 import '../providers/database_provider.dart';
 import '../utils/format.dart';
+import '../utils/date_picker_locale.dart';
 import '../utils/validators.dart';
 import 'dialogs.dart';
 import 'form_fields.dart';
@@ -159,6 +160,7 @@ class _TradeFormState extends State<TradeForm> {
   Future<void> _selectDate(BuildContext context) async {
     final pickedDate = await showDatePicker(
       context: context,
+      locale: resolveDatePickerLocale(Localizations.localeOf(context)),
       initialDate: _datetime,
       firstDate: DateTime(2000),
       lastDate: DateTime.now(),

--- a/test/utils/date_picker_locale_test.dart
+++ b/test/utils/date_picker_locale_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xfin/utils/date_picker_locale.dart';
+
+void main() {
+  group('resolveDatePickerLocale', () {
+    test('maps english to en_GB to keep monday as first day', () {
+      expect(resolveDatePickerLocale(const Locale('en')), const Locale('en', 'GB'));
+    });
+
+    test('keeps german locale unchanged', () {
+      expect(resolveDatePickerLocale(const Locale('de')), const Locale('de'));
+    });
+  });
+}


### PR DESCRIPTION
### Motivation
- The date picker shows a Sunday-first week when the app `Locale` is English, which is unexpected compared to the German locale that starts weeks on Monday. 
- The intent is to make calendar grid week starts consistent (Monday-first) regardless of an English language selection. 

### Description
- Added a small helper `resolveDatePickerLocale` in `lib/utils/date_picker_locale.dart` that maps `en` to `Locale('en','GB')` and returns other locales unchanged. 
- Updated all `showDatePicker` calls in `lib/widgets/form_fields.dart`, `lib/widgets/trade_form.dart`, and `lib/screens/settings_screen.dart` to pass `locale: resolveDatePickerLocale(Localizations.localeOf(context))`. 
- Added unit tests in `test/utils/date_picker_locale_test.dart` verifying that `en` maps to `en_GB` and that `de` remains unchanged. 

### Testing
- Checked for Flutter/Dart toolchain with `which fvm || which flutter || which dart || echo none`, which returned `none` in this environment so the SDK is not available. 
- Attempts to run `dart`/`flutter` format commands failed due to missing binaries, so automated formatting could not be executed here. 
- The new unit test file `test/utils/date_picker_locale_test.dart` was added but `flutter test` could not be run in this environment, so tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69981898a8cc8332b7cc16f42f4e8f13)