### PR TITLE
Refactor allocation widgets, add 200-day SMA and fix asset analysis history

### DIFF
--- a/lib/database/daos/assets_dao.dart
+++ b/lib/database/daos/assets_dao.dart
@@ -36,13 +36,18 @@ class AssetsDao extends DatabaseAccessor<AppDatabase> with _$AssetsDaoMixin {
     for (final trade in trades) {
       final date = intToDateTime(trade.datetime ~/ 1000000)!;
       final dateOnly = DateTime(date.year, date.month, date.day);
-      final signedShares =
-          trade.type == TradeTypes.buy ? trade.shares : -trade.shares;
+
+      final sharesDelta = assetId == 1
+          ? -trade.targetAccountValueDelta
+          : (trade.type == TradeTypes.buy ? trade.shares : -trade.shares);
+      final valueDelta = assetId == 1
+          ? -trade.targetAccountValueDelta
+          : trade.targetAccountValueDelta;
 
       final current = dailyDeltas[dateOnly] ?? const _AssetValueDelta();
       dailyDeltas[dateOnly] = _AssetValueDelta(
-        shares: current.shares + signedShares,
-        value: current.value + trade.targetAccountValueDelta,
+        shares: current.shares + sharesDelta,
+        value: current.value + valueDelta,
       );
     }
 
@@ -62,28 +67,42 @@ class AssetsDao extends DatabaseAccessor<AppDatabase> with _$AssetsDaoMixin {
     if (dailyDeltas.isEmpty) {
       final now = DateTime.now();
       final today = DateTime(now.year, now.month, now.day);
-      sharesHistory.add(FlSpot(today.millisecondsSinceEpoch.toDouble(), asset.shares));
-      valueHistory.add(FlSpot(today.millisecondsSinceEpoch.toDouble(), asset.value));
+      sharesHistory
+          .add(FlSpot(today.millisecondsSinceEpoch.toDouble(), normalize(asset.shares)));
+      valueHistory
+          .add(FlSpot(today.millisecondsSinceEpoch.toDouble(), normalize(asset.value)));
     } else {
       final sortedDates = dailyDeltas.keys.toList()..sort();
       final firstDate = sortedDates.first;
       final now = DateTime.now();
       final today = DateTime(now.year, now.month, now.day);
-      final tomorrow = today.add(const Duration(days: 1));
 
-      double runningShares = 0;
-      double runningValue = 0;
+      final historyByDate = <DateTime, _AssetValueDelta>{};
+      double runningShares = asset.shares;
+      double runningValue = asset.value;
+
+      for (var date = today;
+          !date.isBefore(firstDate);
+          date = date.subtract(const Duration(days: 1))) {
+        final dateOnly = DateTime(date.year, date.month, date.day);
+        historyByDate[dateOnly] =
+            _AssetValueDelta(shares: runningShares, value: runningValue);
+
+        final delta = dailyDeltas[dateOnly] ?? const _AssetValueDelta();
+        runningShares -= delta.shares;
+        runningValue -= delta.value;
+      }
 
       for (var date = firstDate;
-          date.isBefore(tomorrow);
+          !date.isAfter(today);
           date = date.add(const Duration(days: 1))) {
         final dateOnly = DateTime(date.year, date.month, date.day);
-        final delta = dailyDeltas[dateOnly] ?? const _AssetValueDelta();
-        runningShares += delta.shares;
-        runningValue += delta.value;
+        final point = historyByDate[dateOnly] ?? const _AssetValueDelta();
 
-        sharesHistory.add(FlSpot(dateOnly.millisecondsSinceEpoch.toDouble(), normalize(runningShares)));
-        valueHistory.add(FlSpot(dateOnly.millisecondsSinceEpoch.toDouble(), normalize(runningValue)));
+        sharesHistory.add(FlSpot(
+            dateOnly.millisecondsSinceEpoch.toDouble(), normalize(point.shares)));
+        valueHistory.add(FlSpot(
+            dateOnly.millisecondsSinceEpoch.toDouble(), normalize(point.value)));
       }
     }
 

--- a/lib/screens/asset_analysis_detail_screen.dart
+++ b/lib/screens/asset_analysis_detail_screen.dart
@@ -9,6 +9,7 @@ import '../database/daos/assets_dao.dart';
 import '../providers/database_provider.dart';
 import '../utils/format.dart';
 import '../widgets/analysis_line_chart_section.dart';
+import '../widgets/charts.dart';
 import '../widgets/liquid_glass_widgets.dart';
 
 class AssetAnalysisDetailScreen extends StatefulWidget {
@@ -27,6 +28,7 @@ class _AssetAnalysisDetailScreenState extends State<AssetAnalysisDetailScreen> {
   bool _showSma = false;
   bool _showEma = false;
   bool _showBb = false;
+  bool _showSma200 = false;
   LineBarSpot? _touchedSpot;
   int _chartPointerCount = 0;
 
@@ -70,25 +72,7 @@ class _AssetAnalysisDetailScreenState extends State<AssetAnalysisDetailScreen> {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Wrap(
-                      alignment: WrapAlignment.end,
-                      spacing: 8,
-                      children: [
-                        ChoiceChip(
-                          label: Text(l10n.value),
-                          selected: !_showShares,
-                          showCheckmark: false,
-                          onSelected: (_) => setState(() => _showShares = false),
-                        ),
-                        ChoiceChip(
-                          label: Text(l10n.shares),
-                          selected: _showShares,
-                          showCheckmark: false,
-                          onSelected: (_) => setState(() => _showShares = true),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 12),
+
                     AnalysisLineChartSection(
                       allData: _showShares ? data.sharesHistory : data.valueHistory,
                       startValue: 0,
@@ -100,9 +84,12 @@ class _AssetAnalysisDetailScreenState extends State<AssetAnalysisDetailScreen> {
                         });
                       },
                       showSma: _showSma,
+                      showSma200: _showSma200,
                       showEma: _showEma,
                       showBb: _showBb,
+                      showSma200Toggle: true,
                       onShowSmaChanged: (value) => setState(() => _showSma = value),
+                      onShowSma200Changed: (value) => setState(() => _showSma200 = value),
                       onShowEmaChanged: (value) => setState(() => _showEma = value),
                       onShowBbChanged: (value) => setState(() => _showBb = value),
                       touchedSpot: _touchedSpot,
@@ -113,59 +100,54 @@ class _AssetAnalysisDetailScreenState extends State<AssetAnalysisDetailScreen> {
                       valueFormatter: _showShares
                           ? (value) => value.toStringAsFixed(4)
                           : formatCurrency,
+                      valueLabel: l10n.total,
+                      topRight: Wrap(
+                        alignment: WrapAlignment.end,
+                        spacing: 8,
+                        children: [
+                          ChoiceChip(
+                            label: Text(l10n.value),
+                            selected: !_showShares,
+                            showCheckmark: false,
+                            onSelected: (_) => setState(() => _showShares = false),
+                          ),
+                          ChoiceChip(
+                            label: Text(l10n.shares),
+                            selected: _showShares,
+                            showCheckmark: false,
+                            onSelected: (_) => setState(() => _showShares = true),
+                          ),
+                        ],
+                      ),
                     ),
-                    const SizedBox(height: 16),
+                    const SizedBox(height: 12),
                     _sectionTitle(context, 'Trading stats'),
                     _statTile('Buys', data.buys.toString()),
                     _statTile('Sells', data.sells.toString()),
                     _statTile('Total profit', formatCurrency(data.totalProfit)),
                     _statTile('Total fees', formatCurrency(data.totalFees)),
                     _statTile('Trade volume', formatCurrency(data.tradeVolume)),
-                    const SizedBox(height: 16),
+                    const SizedBox(height: 12),
                     _sectionTitle(context, 'General stats'),
                     _statTile('Booking inflows', formatCurrency(data.bookingInflows)),
                     _statTile('Booking outflows', formatCurrency(data.bookingOutflows)),
                     _statTile('Transfers', data.transferCount.toString()),
                     _statTile('Transfer volume', formatCurrency(data.transferVolume)),
                     _statTile('Events per month', data.eventFrequency.toStringAsFixed(1)),
-                    const SizedBox(height: 16),
+                    const SizedBox(height: 12),
                     _sectionTitle(context, 'Held on accounts'),
                     if (data.accountHoldings.isEmpty)
                       const Padding(
                         padding: EdgeInsets.all(8),
                         child: Text('No account positions.'),
                       )
-                    else ...[
-                      SizedBox(
-                        height: 220,
-                        child: PieChart(
-                          PieChartData(
-                            centerSpaceRadius: 40,
-                            sectionsSpace: 3,
-                            sections: List.generate(data.accountHoldings.length, (i) {
-                              final h = data.accountHoldings[i];
-                              return PieChartSectionData(
-                                value: h.value,
-                                color: [
-                                  const Color(0xFF3B82F6),
-                                  const Color(0xFF2563EB),
-                                  const Color(0xFF1D4ED8),
-                                  const Color(0xFF1E40AF),
-                                ][i % 4],
-                                title: '',
-                                radius: 78,
-                              );
-                            }),
-                          ),
-                        ),
+                    else
+                      AllocationBreakdownSection(
+                        items: data.accountHoldings
+                            .map((h) => AllocationItem(label: h.label, value: h.value))
+                            .toList(),
+                        title: l10n.investments,
                       ),
-                      ...data.accountHoldings.map((h) => ListTile(
-                            dense: true,
-                            contentPadding: EdgeInsets.zero,
-                            title: Text(h.label),
-                            trailing: Text(formatCurrency(h.value)),
-                          )),
-                    ],
                   ],
                 ),
               ),
@@ -183,10 +165,10 @@ class _AssetAnalysisDetailScreenState extends State<AssetAnalysisDetailScreen> {
 
   Widget _statTile(String label, String value) {
     return ListTile(
-      dense: true,
+      visualDensity: const VisualDensity(vertical: -3),
       contentPadding: EdgeInsets.zero,
-      title: Text(label),
-      trailing: Text(value, style: const TextStyle(fontWeight: FontWeight.w600)),
+      title: Text(label, style: const TextStyle(fontSize: 16)),
+      trailing: Text(value, style: const TextStyle(fontWeight: FontWeight.w600, fontSize: 16)),
     );
   }
 }

--- a/lib/screens/assets_screen.dart
+++ b/lib/screens/assets_screen.dart
@@ -1,12 +1,11 @@
-import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:xfin/database/app_database.dart';
 import 'package:xfin/database/tables.dart';
 import 'package:xfin/l10n/app_localizations.dart';
 import 'package:xfin/utils/format.dart';
-import 'package:xfin/utils/global_constants.dart';
 import 'package:xfin/widgets/asset_form.dart';
+import 'package:xfin/widgets/charts.dart';
 import 'package:xfin/widgets/dialogs.dart';
 
 import '../providers/database_provider.dart';
@@ -65,7 +64,7 @@ class _AssetsScreenState extends State<AssetsScreen> {
     }
   }
 
-  Future<List<_AllocationItem>> _loadAllocationItems(AppDatabase db) async {
+  Future<List<AllocationItem>> _loadAllocationItems(AppDatabase db) async {
     final assets = (await db.assetsDao.getAllAssets())
         .where((a) => !a.isArchived)
         .toList();
@@ -76,7 +75,7 @@ class _AssetsScreenState extends State<AssetsScreen> {
             ifAbsent: () => asset.value);
       }
       return byType.entries
-          .map((e) => _AllocationItem(
+          .map((e) => AllocationItem(
                 label: e.key.name.toUpperCase(),
                 value: e.value,
                 type: e.key,
@@ -88,42 +87,15 @@ class _AssetsScreenState extends State<AssetsScreen> {
 
     return assets
         .where((a) => a.type == _selectedType)
-        .map((a) => _AllocationItem(label: a.name, value: a.value, asset: a))
+        .map((a) => AllocationItem(label: a.name, value: a.value, asset: a))
         .where((e) => e.value > 0)
         .toList()
       ..sort((a, b) => b.value.compareTo(a.value));
   }
 
-  Widget buildAllocationChart(List<_AllocationItem> items) {
-    final total = items.fold<double>(0, (sum, e) => sum + e.value);
-    return SizedBox(
-      height: 240,
-      child: PieChart(
-        PieChartData(
-          sectionsSpace: 3,
-          centerSpaceRadius: 46,
-          startDegreeOffset: -90,
-          sections: List.generate(items.length, (index) {
-            final item = items[index];
-            final ratio = total == 0 ? 0.0 : item.value / total;
-            return PieChartSectionData(
-              value: item.value,
-              color: chartColors[index % chartColors.length],
-              radius: 88,
-              title:
-                  ratio >= 0.08 ? '${(ratio * 100).toStringAsFixed(0)}%' : '',
-              titleStyle:
-                  const TextStyle(fontWeight: FontWeight.w600, fontSize: 11),
-            );
-          }),
-        ),
-      ),
-    );
-  }
-
   Widget _buildAnalysisTab(
       BuildContext context, AppDatabase db, AppLocalizations l10n) {
-    return FutureBuilder<List<_AllocationItem>>(
+    return FutureBuilder<List<AllocationItem>>(
       future: _loadAllocationItems(db),
       builder: (context, snapshot) {
         if (snapshot.connectionState == ConnectionState.waiting) {
@@ -133,7 +105,6 @@ class _AssetsScreenState extends State<AssetsScreen> {
           return Center(child: Text(snapshot.error.toString()));
         }
         final items = snapshot.data ?? [];
-        final total = items.fold<double>(0, (sum, e) => sum + e.value);
         return SingleChildScrollView(
           padding: EdgeInsets.only(
             top: MediaQuery.of(context).padding.top + kToolbarHeight + 12,
@@ -173,42 +144,34 @@ class _AssetsScreenState extends State<AssetsScreen> {
                   child: Text(l10n.noAssetsOfThisTypeYet),
                 ))
               else ...[
-                buildAllocationChart(items),
-                const SizedBox(height: 32),
-                Text(l10n.investments,
-                    style: Theme.of(context).textTheme.titleMedium),
-                ...List.generate(items.length, (index) {
-                  final item = items[index];
-                  double ratio = total == 0 ? 0 : item.value / total;
-                  return ListTile(
-                    contentPadding: EdgeInsets.zero,
-                    leading: CircleAvatar(
-                      radius: 8,
-                      backgroundColor: chartColors[index % 10],
-                    ),
-                    title: Text(
-                        _selectedType == null
-                            ? getAssetTypeName(l10n, item.type!, plural: true)
-                            : item.label,
-                        style: const TextStyle(fontWeight: FontWeight.w600)),
-                    subtitle: Text(formatCurrency(item.value),
-                        style: const TextStyle(color: Colors.grey)),
-                    trailing: Text(formatPercent(ratio),
-                        style: const TextStyle(fontWeight: FontWeight.w700)),
-                    onTap: () {
-                      if (_selectedType == null && item.type != null) {
-                        setState(() => _selectedType = item.type);
-                        return;
-                      }
-                      if (item.asset == null) return;
-                      Navigator.of(context).push(
-                        MaterialPageRoute(
-                            builder: (_) => AssetAnalysisDetailScreen(
-                                assetId: item.asset!.id)),
-                      );
-                    },
-                  );
-                }),
+                AllocationBreakdownSection(
+                  items: items
+                      .map(
+                        (item) => AllocationItem(
+                          label: _selectedType == null
+                              ? getAssetTypeName(l10n, item.type!, plural: true)
+                              : item.label,
+                          value: item.value,
+                          type: item.type,
+                          asset: item.asset,
+                        ),
+                      )
+                      .toList(),
+                  title: l10n.investments,
+                  onItemTap: (item) {
+                    if (_selectedType == null && item.type != null) {
+                      setState(() => _selectedType = item.type);
+                      return;
+                    }
+                    if (item.asset == null) return;
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) =>
+                            AssetAnalysisDetailScreen(assetId: item.asset!.id),
+                      ),
+                    );
+                  },
+                ),
               ],
             ],
           ),
@@ -311,14 +274,4 @@ class _AssetsScreenState extends State<AssetsScreen> {
       ),
     );
   }
-}
-
-class _AllocationItem {
-  final String label;
-  final double value;
-  final AssetTypes? type;
-  final Asset? asset;
-
-  const _AllocationItem(
-      {required this.label, required this.value, this.type, this.asset});
 }

--- a/lib/widgets/analysis_line_chart_section.dart
+++ b/lib/widgets/analysis_line_chart_section.dart
@@ -19,14 +19,19 @@ class AnalysisLineChartSection extends StatelessWidget {
   final bool showSma;
   final bool showEma;
   final bool showBb;
+  final bool showSma200;
   final ValueChanged<bool> onShowSmaChanged;
   final ValueChanged<bool> onShowEmaChanged;
   final ValueChanged<bool> onShowBbChanged;
+  final ValueChanged<bool>? onShowSma200Changed;
   final LineBarSpot? touchedSpot;
   final ValueChanged<LineBarSpot?> onTouchedSpotChanged;
   final VoidCallback onPointerDown;
   final VoidCallback onPointerUpOrCancel;
   final ValueFormatter valueFormatter;
+  final bool showSma200Toggle;
+  final String valueLabel;
+  final Widget? topRight;
 
   const AnalysisLineChartSection({
     super.key,
@@ -37,14 +42,19 @@ class AnalysisLineChartSection extends StatelessWidget {
     required this.showSma,
     required this.showEma,
     required this.showBb,
+    this.showSma200 = false,
     required this.onShowSmaChanged,
     required this.onShowEmaChanged,
     required this.onShowBbChanged,
+    this.onShowSma200Changed,
     required this.touchedSpot,
     required this.onTouchedSpotChanged,
     required this.onPointerDown,
     required this.onPointerUpOrCancel,
     required this.valueFormatter,
+    this.showSma200Toggle = false,
+    this.valueLabel = "",
+    this.topRight,
   });
 
   @override
@@ -122,6 +132,17 @@ class AnalysisLineChartSection extends StatelessWidget {
       ));
     }
 
+    if (showSma200) {
+      final smaData200 = IndicatorCalculator.calculateSma(allData, 200);
+      lineBarsData.add(LineChartBarData(
+        spots: smaData200.where((spot) => spot.x >= firstDateInRange).toList(),
+        isCurved: true,
+        barWidth: 2,
+        color: Colors.green,
+        dotData: const FlDotData(show: false),
+      ));
+    }
+
     if (showEma) {
       final emaData = IndicatorCalculator.calculateEma(allData, 30);
       lineBarsData.add(LineChartBarData(
@@ -160,11 +181,34 @@ class AnalysisLineChartSection extends StatelessWidget {
 
     return Column(
       children: [
-        Text(
-          valueFormatter(totalToShow),
-          style: const TextStyle(fontSize: 32, fontWeight: FontWeight.bold),
-        ),
-        const SizedBox(height: 16),
+        if (topRight == null) ...[
+          Text(
+            valueFormatter(totalToShow),
+            style: const TextStyle(fontSize: 32, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 16),
+        ] else ...[
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (valueLabel.isNotEmpty)
+                      Text(valueLabel, style: Theme.of(context).textTheme.bodySmall),
+                    Text(
+                      valueFormatter(totalToShow),
+                      style: const TextStyle(fontSize: 32, fontWeight: FontWeight.bold),
+                    ),
+                  ],
+                ),
+              ),
+              topRight!,
+            ],
+          ),
+          const SizedBox(height: 16),
+        ],
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
@@ -333,67 +377,36 @@ class AnalysisLineChartSection extends StatelessWidget {
           ),
         ),
         const SizedBox(height: 16),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceAround,
+        Wrap(
+          spacing: 12,
+          runSpacing: 4,
+          alignment: WrapAlignment.center,
           children: [
-            Row(
-              children: [
-                Checkbox(
-                  value: showSma,
-                  activeColor: Colors.orange,
-                  onChanged: (value) => onShowSmaChanged(value!),
-                ),
-                Text(
-                  '30-SMA',
-                  style: TextStyle(
-                    color: showSma
-                        ? Colors.orange
-                        : isDark
-                            ? Colors.white
-                            : Colors.black,
-                  ),
-                ),
-              ],
-            ),
-            Row(
-              children: [
-                Checkbox(
-                  value: showEma,
-                  activeColor: Colors.purple,
-                  onChanged: (value) => onShowEmaChanged(value!),
-                ),
-                Text(
-                  '30-EMA',
-                  style: TextStyle(
-                    color: showEma
-                        ? Colors.purple
-                        : isDark
-                            ? Colors.white
-                            : Colors.black,
-                  ),
-                ),
-              ],
-            ),
-            Row(
-              children: [
-                Checkbox(
-                  value: showBb,
-                  activeColor: Colors.blue,
-                  onChanged: (value) => onShowBbChanged(value!),
-                ),
-                Text(
-                  '20-BB',
-                  style: TextStyle(
-                    color: showBb
-                        ? Colors.blue
-                        : isDark
-                            ? Colors.white
-                            : Colors.black,
-                  ),
-                ),
-              ],
-            ),
+            _buildIndicatorToggle(isDark, showSma, Colors.orange, '30-SMA', (v) => onShowSmaChanged(v)),
+            if (showSma200Toggle)
+              _buildIndicatorToggle(isDark, showSma200, Colors.green, '200-SMA', (v) => onShowSma200Changed?.call(v)),
+            _buildIndicatorToggle(isDark, showEma, Colors.purple, '30-EMA', (v) => onShowEmaChanged(v)),
+            _buildIndicatorToggle(isDark, showBb, Colors.blue, '20-BB', (v) => onShowBbChanged(v)),
           ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildIndicatorToggle(bool isDark, bool selected, Color color, String label, ValueChanged<bool> onChanged) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Checkbox(
+          value: selected,
+          activeColor: color,
+          onChanged: (value) => onChanged(value ?? false),
+        ),
+        Text(
+          label,
+          style: TextStyle(
+            color: selected ? color : isDark ? Colors.white : Colors.black,
+          ),
         ),
       ],
     );

--- a/lib/widgets/charts.dart
+++ b/lib/widgets/charts.dart
@@ -1,8 +1,9 @@
 import 'package:fl_chart/fl_chart.dart';
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 
 import '../database/app_database.dart';
 import '../database/tables.dart';
+import '../utils/format.dart';
 import '../utils/global_constants.dart';
 
 class AllocationItem {
@@ -11,33 +12,93 @@ class AllocationItem {
   final AssetTypes? type;
   final Asset? asset;
 
-  const AllocationItem(
-      {required this.label, required this.value, this.type, this.asset});
+  const AllocationItem({
+    required this.label,
+    required this.value,
+    this.type,
+    this.asset,
+  });
 }
 
-Widget buildAllocationChart(List<AllocationItem> items) {
-  final total = items.fold<double>(0, (sum, e) => sum + e.value);
-  return SizedBox(
-    height: 240,
-    child: PieChart(
-      PieChartData(
-        sectionsSpace: 3,
-        centerSpaceRadius: 46,
-        startDegreeOffset: -90,
-        sections: List.generate(items.length, (index) {
+class AllocationBreakdownSection extends StatelessWidget {
+  final List<AllocationItem> items;
+  final String title;
+  final ValueChanged<AllocationItem>? onItemTap;
+
+  const AllocationBreakdownSection({
+    super.key,
+    required this.items,
+    required this.title,
+    this.onItemTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final total = items.fold<double>(0, (sum, e) => sum + e.value);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        AllocationPieChart(items: items),
+        const SizedBox(height: 32),
+        Text(title, style: Theme.of(context).textTheme.titleMedium),
+        ...List.generate(items.length, (index) {
           final item = items[index];
           final ratio = total == 0 ? 0.0 : item.value / total;
-          return PieChartSectionData(
-            value: item.value,
-            color: chartColors[index % chartColors.length],
-            radius: 88,
-            title:
-            ratio >= 0.08 ? '${(ratio * 100).toStringAsFixed(0)}%' : '',
-            titleStyle:
-            const TextStyle(fontWeight: FontWeight.w600, fontSize: 11),
+          return ListTile(
+            contentPadding: EdgeInsets.zero,
+            leading: CircleAvatar(
+              radius: 8,
+              backgroundColor: chartColors[index % chartColors.length],
+            ),
+            title: Text(
+              item.label,
+              style: const TextStyle(fontWeight: FontWeight.w600),
+            ),
+            subtitle: Text(
+              formatCurrency(item.value),
+              style: const TextStyle(color: Colors.grey),
+            ),
+            trailing: Text(
+              formatPercent(ratio),
+              style: const TextStyle(fontWeight: FontWeight.w700),
+            ),
+            onTap: onItemTap == null ? null : () => onItemTap!(item),
           );
         }),
+      ],
+    );
+  }
+}
+
+class AllocationPieChart extends StatelessWidget {
+  final List<AllocationItem> items;
+
+  const AllocationPieChart({super.key, required this.items});
+
+  @override
+  Widget build(BuildContext context) {
+    final total = items.fold<double>(0, (sum, e) => sum + e.value);
+    return SizedBox(
+      height: 240,
+      child: PieChart(
+        PieChartData(
+          sectionsSpace: 3,
+          centerSpaceRadius: 46,
+          startDegreeOffset: -90,
+          sections: List.generate(items.length, (index) {
+            final item = items[index];
+            final ratio = total == 0 ? 0.0 : item.value / total;
+            return PieChartSectionData(
+              value: item.value,
+              color: chartColors[index % chartColors.length],
+              radius: 88,
+              title: ratio >= 0.08 ? '${(ratio * 100).toStringAsFixed(0)}%' : '',
+              titleStyle: const TextStyle(fontWeight: FontWeight.w600, fontSize: 11),
+            );
+          }),
+        ),
       ),
-    ),
-  );
+    );
+  }
 }

--- a/test/database/daos/assets_dao_test.dart
+++ b/test/database/daos/assets_dao_test.dart
@@ -320,17 +320,48 @@ void main() {
         expect(details.accountHoldings.single.label, 'Broker');
         expect(details.accountHoldings.single.value, 250);
 
-        // Running totals by day from 2024-01-01 to today:
-        // day1: shares 2, value 100
-        // day2: shares 2.5, value 120
-        // day3: shares 1.3, value 55
-        expect(details.sharesHistory.first.y, closeTo(2, 1e-9));
-        expect(details.valueHistory.first.y, closeTo(100, 1e-9));
-        expect(details.sharesHistory[1].y, closeTo(2.5, 1e-9));
-        expect(details.valueHistory[1].y, closeTo(120, 1e-9));
-        expect(details.sharesHistory[2].y, closeTo(1.3, 1e-9));
-        expect(details.valueHistory[2].y, closeTo(55, 1e-9));
+        expect(details.sharesHistory.first.y, closeTo(7.7, 1e-9));
+        expect(details.valueHistory.first.y, closeTo(395, 1e-9));
+        expect(details.sharesHistory[1].y, closeTo(8.2, 1e-9));
+        expect(details.valueHistory[1].y, closeTo(415, 1e-9));
+        expect(details.sharesHistory[2].y, closeTo(7.0, 1e-9));
+        expect(details.valueHistory[2].y, closeTo(350, 1e-9));
+        expect(details.sharesHistory.last.y, closeTo(7, 1e-9));
+        expect(details.valueHistory.last.y, closeTo(350, 1e-9));
       });
+
+      test('treats base currency trades with inverse target delta for history', () async {
+        await db.into(db.assets).insert(AssetsCompanion.insert(
+          id: const Value(1),
+          name: 'Euro',
+          type: AssetTypes.fiat,
+          tickerSymbol: 'EUR',
+          value: const Value(6000),
+          shares: const Value(6000),
+          netCostBasis: const Value(1),
+          brokerCostBasis: const Value(1),
+          buyFeeTotal: const Value(0),
+        ));
+
+        await db.into(db.trades).insert(TradesCompanion.insert(
+          datetime: 20240101120000,
+          type: TradeTypes.buy,
+          sourceAccountId: cashId,
+          targetAccountId: brokerId,
+          assetId: const Value(1),
+          shares: 0,
+          costBasis: 1,
+          sourceAccountValueDelta: -1000,
+          targetAccountValueDelta: 1000,
+        ));
+
+        final details = await assetsDao.getAssetAnalysisDetails(1);
+
+        expect(details.valueHistory.last.y, closeTo(6000, 1e-9));
+        expect(details.sharesHistory.last.y, closeTo(6000, 1e-9));
+        expect(details.valueHistory.first.y, closeTo(6000, 1e-9));
+      });
+
     });
   });
 }


### PR DESCRIPTION
### Motivation
- Make the pie chart + corresponding list reusable across the app so AssetsScreen and AssetAnalysisDetailScreen share identical styling and behavior.
- Add a 200-day SMA indicator (green) to the line chart and provide a detail-screen layout where the total appears left and shares/value toggles appear right on the same line.
- Fix incorrect historical series calculation in `getAssetAnalysisDetails` so initial balances are preserved and handle base-currency (asset id == 1) trades correctly.
- Tighten stat row spacing and increase text size for better readability in the detail screen.

### Description
- Extracted allocation UI into `lib/widgets/charts.dart` as `AllocationPieChart`, `AllocationBreakdownSection`, and `AllocationItem` and replaced duplicate chart/list code in `AssetsScreen` and `AssetAnalysisDetailScreen` to reuse the component.
- Extended `AnalysisLineChartSection` to support a 200-SMA (`showSma200`) rendered in green, a `showSma200Toggle` option, and optional `valueLabel`/`topRight` props so the detail screen can display the total on the left and the shares/value chips on the right in a single row without changing analysis-screen behavior.
- Fixed `AssetsDao.getAssetAnalysisDetails` to build running histories anchored from the current asset totals (so initial balances are included) and added special-case handling for base-currency trades (`assetId == 1`) where trade deltas use `-targetAccountValueDelta` per the requested rule.
- Updated `AssetAnalysisDetailScreen` to enable the 200-SMA toggle, pass the new top-row layout (total + chips), replace the account-holdings pie/list with the shared `AllocationBreakdownSection`, and adjust stat-row visual density and font sizes.
- Updated `test/database/daos/assets_dao_test.dart` expectations and added a test validating the base-currency trade handling.

### Testing
- Attempted to run unit tests with `flutter test test/database/daos/assets_dao_test.dart` but the environment lacks Flutter tooling so the run failed (`flutter` not found).
- Attempted to run `dart format` but `dart` is not available in this environment, so formatting checks were not executed.
- A UI smoke capture via Playwright was attempted but no local app server was reachable, producing an `ERR_EMPTY_RESPONSE`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699af5ddd3148332a891029b012b7407)