### PR TITLE
Add Calendar screen, analysis pie-chart linkage, and asset archiving

### DIFF
--- a/lib/database/daos/analysis_dao.dart
+++ b/lib/database/daos/analysis_dao.dart
@@ -511,6 +511,57 @@ class AnalysisDao extends DatabaseAccessor<AppDatabase>
   }
 
   // Singles
+  Future<Map<int, double>> getDailyNetFlowInRange({
+    required DateTime start,
+    required DateTime end,
+  }) async {
+    final startInt = start.year * 10000 + start.month * 100 + start.day;
+    final endInt = end.year * 10000 + end.month * 100 + end.day;
+
+    final bookingRows = await (select(bookings)
+          ..where((b) => b.date.isBetweenValues(startInt, endInt)))
+        .get();
+    final tradeRows = await (select(trades)
+          ..where((t) => t.datetime
+              .isBetweenValues(startInt * 1000000, endInt * 1000000 + 235959)))
+        .get();
+
+    final result = <int, double>{};
+
+    for (final booking in bookingRows) {
+      result.update(booking.date, (value) => value + booking.value,
+          ifAbsent: () => booking.value);
+    }
+
+    for (final trade in tradeRows) {
+      final dateInt = trade.datetime ~/ 1000000;
+      final tradeNet =
+          trade.sourceAccountValueDelta + trade.targetAccountValueDelta;
+      result.update(dateInt, (value) => value + tradeNet,
+          ifAbsent: () => tradeNet);
+    }
+
+    return result;
+  }
+
+  Future<MonthlyAnalysisSnapshot> getMonthlyAnalysisSnapshot(DateTime date) async {
+    final results = await Future.wait([
+      getTotalInflowsForMonth(date),
+      getTotalOutflowsForMonth(date),
+      getProfitAndLossForMonth(date),
+      getCategoryInflowsForMonth(date),
+      getCategoryOutflowsForMonth(date),
+    ]);
+
+    return MonthlyAnalysisSnapshot(
+      inflows: results[0] as double,
+      outflows: results[1] as double,
+      profit: results[2] as double,
+      categoryInflows: results[3] as Map<String, double>,
+      categoryOutflows: results[4] as Map<String, double>,
+    );
+  }
+
   Future<List<FlSpot>> getBalanceHistory() async {
     final futureResults = await Future.wait([
       db.accountsDao.getSumOfInitialBalances(),
@@ -563,4 +614,20 @@ class AnalysisDao extends DatabaseAccessor<AppDatabase>
 
     return spots;
   }
+}
+
+class MonthlyAnalysisSnapshot {
+  final double inflows;
+  final double outflows;
+  final double profit;
+  final Map<String, double> categoryInflows;
+  final Map<String, double> categoryOutflows;
+
+  const MonthlyAnalysisSnapshot({
+    required this.inflows,
+    required this.outflows,
+    required this.profit,
+    required this.categoryInflows,
+    required this.categoryOutflows,
+  });
 }

--- a/lib/database/daos/assets_dao.dart
+++ b/lib/database/daos/assets_dao.dart
@@ -203,8 +203,21 @@ class AssetsDao extends DatabaseAccessor<AppDatabase> with _$AssetsDaoMixin {
     );
   }
 
-  Stream<List<Asset>> watchAllAssets() =>
-      (select(assets)..orderBy([(t) => OrderingTerm.desc(t.value)])).watch();
+  Future<void> setArchived(int assetId, bool archived) {
+    return (update(assets)..where((a) => a.id.equals(assetId))).write(
+      AssetsCompanion(isArchived: Value(archived)),
+    );
+  }
+
+  Stream<List<Asset>> watchAllAssets() => (select(assets)
+        ..where((a) => a.isArchived.equals(false))
+        ..orderBy([(t) => OrderingTerm.desc(t.value)]))
+      .watch();
+
+  Stream<List<Asset>> watchArchivedAssets() => (select(assets)
+        ..where((a) => a.isArchived.equals(true))
+        ..orderBy([(t) => OrderingTerm.desc(t.value)]))
+      .watch();
 
 }
 

--- a/lib/screens/analysis_screen.dart
+++ b/lib/screens/analysis_screen.dart
@@ -7,6 +7,7 @@ import '../app_theme.dart';
 import '../database/app_database.dart';
 import '../providers/database_provider.dart';
 import '../utils/format.dart';
+import '../utils/global_constants.dart';
 import '../widgets/analysis_line_chart_section.dart';
 
 // A data class to hold all asynchronous results needed by AnalysisScreen
@@ -41,6 +42,19 @@ class AnalysisScreen extends StatefulWidget {
 
   @override
   State<AnalysisScreen> createState() => _AnalysisScreenState();
+}
+
+
+class _CategoryDisplayData {
+  final List<MapEntry<String, double>> entries;
+  final double totalAmount;
+  final bool hasOther;
+
+  const _CategoryDisplayData({
+    required this.entries,
+    required this.totalAmount,
+    required this.hasOther,
+  });
 }
 
 class _AnalysisScreenState extends State<AnalysisScreen> {
@@ -210,7 +224,9 @@ class _AnalysisScreenState extends State<AnalysisScreen> {
                     child: Column(
                       children: [
                         _buildInflowOutflowSwitch(),
-                        const SizedBox(height: 8),
+                        const SizedBox(height: 12),
+                        _buildCategoryPieChart(analysisData),
+                        const SizedBox(height: 12),
                         _buildCategoryList(analysisData),
                       ],
                     ),
@@ -363,7 +379,7 @@ class _AnalysisScreenState extends State<AnalysisScreen> {
     );
   }
 
-  Widget _buildCategoryList(AnalysisData analysisData) {
+  _CategoryDisplayData _getDisplayCategoryData(AnalysisData analysisData) {
     final Map<String, double> categories = _showInflows
         ? analysisData.currentMonthCategoryInflows
         : analysisData.currentMonthCategoryOutflows;
@@ -371,37 +387,95 @@ class _AnalysisScreenState extends State<AnalysisScreen> {
     final double totalAmount =
         categories.values.fold(0.0, (sum, item) => sum + item.abs());
 
-    // Sort categories by absolute amount in descending order
-    List<MapEntry<String, double>> sortedCategories = categories.entries
-        .toList()
+    final sortedCategories = categories.entries.toList()
       ..sort((a, b) => b.value.abs().compareTo(a.value.abs()));
 
-    List<Widget> categoryWidgets = [];
+    final visible = <MapEntry<String, double>>[];
     double aggregatedOtherAmount = 0.0;
     bool hasOther = false;
 
-    for (int i = 0; i < sortedCategories.length; i++) {
-      final entry = sortedCategories[i];
-      final percentage = (entry.value.abs() / totalAmount) * 100;
-
-      if (!_showAllCategories &&
-          percentage < 1.0 &&
-          i < sortedCategories.length) {
+    for (final entry in sortedCategories) {
+      final percentage = totalAmount == 0 ? 0.0 : (entry.value.abs() / totalAmount) * 100;
+      if (!_showAllCategories && percentage < 1.0) {
         aggregatedOtherAmount += entry.value;
         hasOther = true;
       } else {
-        categoryWidgets
-            .add(_buildCategoryRow(entry.key, entry.value, percentage));
+        visible.add(entry);
       }
     }
 
-    if (hasOther) {
-      final otherPercentage = (aggregatedOtherAmount.abs() / totalAmount) * 100;
-      categoryWidgets.add(
-          _buildCategoryRow('...', aggregatedOtherAmount, otherPercentage));
+    if (hasOther && aggregatedOtherAmount != 0) {
+      visible.add(MapEntry('...', aggregatedOtherAmount));
     }
 
-    if (hasOther && !_showAllCategories) {
+    return _CategoryDisplayData(
+      entries: visible,
+      totalAmount: totalAmount,
+      hasOther: hasOther,
+    );
+  }
+
+  Widget _buildCategoryPieChart(AnalysisData analysisData) {
+    final data = _getDisplayCategoryData(analysisData);
+    if (data.entries.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return SizedBox(
+      height: 220,
+      child: PieChart(
+        PieChartData(
+          sectionsSpace: 3,
+          centerSpaceRadius: 40,
+          startDegreeOffset: -90,
+          sections: List.generate(data.entries.length, (index) {
+            final entry = data.entries[index];
+            final ratio = data.totalAmount == 0
+                ? 0.0
+                : entry.value.abs() / data.totalAmount;
+            return PieChartSectionData(
+              value: entry.value.abs(),
+              color: chartColors[index % chartColors.length],
+              radius: 84,
+              title: ratio >= 0.08 ? '${(ratio * 100).toStringAsFixed(0)}%' : '',
+              titleStyle:
+                  const TextStyle(fontWeight: FontWeight.w600, fontSize: 11),
+            );
+          }),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCategoryList(AnalysisData analysisData) {
+    final Map<String, double> categories = _showInflows
+        ? analysisData.currentMonthCategoryInflows
+        : analysisData.currentMonthCategoryOutflows;
+
+    if (categories.isEmpty) {
+      return const Center(
+          child: Text('Keine Daten für diese Kategorie verfügbar.'));
+    }
+
+    final data = _getDisplayCategoryData(analysisData);
+    final categoryWidgets = <Widget>[];
+
+    for (var i = 0; i < data.entries.length; i++) {
+      final entry = data.entries[i];
+      final percentage = data.totalAmount == 0
+          ? 0.0
+          : (entry.value.abs() / data.totalAmount) * 100;
+      categoryWidgets.add(
+        _buildCategoryRow(
+          category: entry.key,
+          amount: entry.value,
+          percentage: percentage,
+          color: chartColors[i % chartColors.length],
+        ),
+      );
+    }
+
+    if (data.hasOther && !_showAllCategories) {
       categoryWidgets.add(
         TextButton(
           onPressed: () {
@@ -415,7 +489,7 @@ class _AnalysisScreenState extends State<AnalysisScreen> {
           child: const Text('Alle anzeigen'),
         ),
       );
-    } else if (!hasOther && _showAllCategories) {
+    } else if (!data.hasOther && _showAllCategories) {
       categoryWidgets.add(
         TextButton(
           onPressed: () {
@@ -431,21 +505,34 @@ class _AnalysisScreenState extends State<AnalysisScreen> {
       );
     }
 
-    if (categories.isEmpty) {
-      return const Center(
-          child: Text('Keine Daten für diese Kategorie verfügbar.'));
-    }
-
     return Column(children: categoryWidgets);
   }
 
-  Widget _buildCategoryRow(String category, double amount, double percentage) {
+  Widget _buildCategoryRow({
+    required String category,
+    required double amount,
+    required double percentage,
+    required Color color,
+  }) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          Text(category),
+          Expanded(
+            child: Row(
+              children: [
+                Container(
+                  width: 10,
+                  height: 10,
+                  decoration:
+                      BoxDecoration(color: color, shape: BoxShape.circle),
+                ),
+                const SizedBox(width: 8),
+                Expanded(child: Text(category)),
+              ],
+            ),
+          ),
           Row(
             children: [
               Text(formatCurrency(amount)),

--- a/lib/screens/assets_screen.dart
+++ b/lib/screens/assets_screen.dart
@@ -38,30 +38,74 @@ class _AssetsScreenState extends State<AssetsScreen> {
     AppLocalizations l10n,
   ) async {
     final hasTrades = await db.assetsDao.hasTrades(asset.id);
-    final hasAssetsOnAccounts =
-        await db.assetsDao.hasAssetsOnAccounts(asset.id);
-    final deletionProhibited =
-        hasTrades || hasAssetsOnAccounts || asset.id == 1;
+    final hasAssetsOnAccounts = await db.assetsDao.hasAssetsOnAccounts(asset.id);
+    final deletionProhibited = hasTrades || hasAssetsOnAccounts || asset.id == 1;
 
     if (!context.mounted) return;
 
     if (deletionProhibited) {
-      showDialog(
-        context: context,
-        builder: (context) => AlertDialog(
-          title: Text(l10n.cannotDeleteAsset),
-          content: Text(l10n.assetHasReferences),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(),
-              child: Text(l10n.ok),
-            ),
-          ],
-        ),
-      );
+      if (asset.id == 1 || asset.value > 0) {
+        showDialog(
+          context: context,
+          builder: (context) => AlertDialog(
+            title: Text(l10n.cannotDeleteAsset),
+            content: Text(l10n.assetHasReferences),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: Text(l10n.ok),
+              ),
+            ],
+          ),
+        );
+      } else {
+        showDialog(
+          context: context,
+          builder: (context) => AlertDialog(
+            title: Text(l10n.cannotDeleteAsset),
+            content: Text(l10n.assetHasReferences),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: Text(l10n.cancel),
+              ),
+              TextButton(
+                onPressed: () {
+                  db.assetsDao.setArchived(asset.id, true);
+                  Navigator.of(context).pop();
+                },
+                child: Text(l10n.archive),
+              ),
+            ],
+          ),
+        );
+      }
     } else {
       showDeleteDialog(context, asset: asset);
     }
+  }
+
+  void _handleArchivedAssetTap(BuildContext context, AppDatabase db, Asset asset) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Unarchive Asset'),
+        content: const Text('Do you want to unarchive this asset?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () {
+              db.assetsDao.setArchived(asset.id, false);
+              Navigator.of(context).pop();
+            },
+            child: const Text('Confirm'),
+          ),
+        ],
+      ),
+    );
   }
 
   Future<List<AllocationItem>> _loadAllocationItems(AppDatabase db) async {
@@ -196,38 +240,55 @@ class _AssetsScreenState extends State<AssetsScreen> {
           return Center(child: Text(l10n.noAssets));
         }
 
-        return ListView.builder(
+        return ListView(
           padding: EdgeInsets.only(
             top: MediaQuery.of(context).padding.top + kToolbarHeight,
+            bottom: 96,
           ),
-          itemCount: assets.length,
-          itemBuilder: (context, index) {
-            final asset = assets[index];
-            return ListTile(
-              title: Text(asset.name),
-              subtitle: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text('${l10n.shares}: ${asset.shares.toStringAsFixed(4)}'),
-                  if (asset.id != 1 && asset.shares > 0) ...[
-                    if ((asset.netCostBasis - asset.brokerCostBasis).abs() <
-                        0.01) ...[
-                      Text(
-                          '${l10n.costBasis}: ${formatCurrency(asset.netCostBasis)}'),
-                    ] else ...[
-                      Text(
-                          '${l10n.netCostBasis}: ${formatCurrency(asset.netCostBasis)}'),
-                      Text(
-                          '${l10n.brokerCostBasis}: ${formatCurrency(asset.brokerCostBasis)}'),
+          children: [
+            ...assets.map((asset) => ListTile(
+                  title: Text(asset.name),
+                  subtitle: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text('${l10n.shares}: ${asset.shares.toStringAsFixed(4)}'),
+                      if (asset.id != 1 && asset.shares > 0) ...[
+                        if ((asset.netCostBasis - asset.brokerCostBasis).abs() < 0.01) ...[
+                          Text('${l10n.costBasis}: ${formatCurrency(asset.netCostBasis)}'),
+                        ] else ...[
+                          Text('${l10n.netCostBasis}: ${formatCurrency(asset.netCostBasis)}'),
+                          Text('${l10n.brokerCostBasis}: ${formatCurrency(asset.brokerCostBasis)}'),
+                        ],
+                      ],
+                      Text('${l10n.value}: ${formatCurrency(asset.value)}'),
                     ],
+                  ),
+                  trailing: Text(getAssetTypeName(l10n, asset.type)),
+                  onLongPress: () => _handleLongPress(context, db, asset, l10n),
+                )),
+            StreamBuilder<List<Asset>>(
+              stream: db.assetsDao.watchArchivedAssets(),
+              builder: (context, archivedSnapshot) {
+                final archivedAssets = archivedSnapshot.data ?? const <Asset>[];
+                if (archivedAssets.isEmpty) {
+                  return const SizedBox.shrink();
+                }
+                return ExpansionTile(
+                  title: const Text('Archived Assets'),
+                  children: [
+                    ...archivedAssets.map((asset) => ListTile(
+                          title: Text(asset.name),
+                          trailing: Text(formatCurrency(asset.value), style: TextStyle(
+                            color: asset.value < 0 ? Colors.red : Colors.green,
+                            fontWeight: FontWeight.bold,
+                          )),
+                          onTap: () => _handleArchivedAssetTap(context, db, asset),
+                        )),
                   ],
-                  Text('${l10n.value}: ${formatCurrency(asset.value)}'),
-                ],
-              ),
-              trailing: Text(getAssetTypeName(l10n, asset.type)),
-              onLongPress: () => _handleLongPress(context, db, asset, l10n),
-            );
-          },
+                );
+              },
+            ),
+          ],
         );
       },
     );

--- a/lib/screens/calendar_screen.dart
+++ b/lib/screens/calendar_screen.dart
@@ -1,0 +1,455 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../app_theme.dart';
+import '../database/daos/analysis_dao.dart';
+import '../providers/database_provider.dart';
+import '../utils/format.dart';
+import '../utils/global_constants.dart';
+import '../widgets/liquid_glass_widgets.dart';
+
+class CalendarScreen extends StatefulWidget {
+  const CalendarScreen({super.key});
+
+  @override
+  State<CalendarScreen> createState() => _CalendarScreenState();
+}
+
+class _CalendarScreenState extends State<CalendarScreen> {
+  static const int _initialPage = 1200;
+  final PageController _pageController = PageController(initialPage: _initialPage);
+  bool _showInflows = true;
+  bool _showAllCategories = false;
+
+  late DateTime _selectedMonth;
+  late Future<_CalendarScreenData> _monthDataFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    final now = DateTime.now();
+    _selectedMonth = DateTime(now.year, now.month);
+    _monthDataFuture = _loadMonthData(_selectedMonth);
+  }
+
+  Future<_CalendarScreenData> _loadMonthData(DateTime month) async {
+    final db = context.read<DatabaseProvider>().db;
+    final start = DateTime(month.year, month.month, 1);
+    final end = DateTime(month.year, month.month + 1, 0);
+
+    final results = await Future.wait([
+      db.analysisDao.getDailyNetFlowInRange(start: start, end: end),
+      db.analysisDao.getMonthlyAnalysisSnapshot(month),
+    ]);
+
+    return _CalendarScreenData(
+      dayNetFlow: results[0] as Map<int, double>,
+      monthlySnapshot: results[1] as MonthlyAnalysisSnapshot,
+    );
+  }
+
+  void _setMonth(DateTime month) {
+    setState(() {
+      _selectedMonth = DateTime(month.year, month.month);
+      _showAllCategories = false;
+      _monthDataFuture = _loadMonthData(_selectedMonth);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Stack(
+        children: [
+          FutureBuilder<_CalendarScreenData>(
+            future: _monthDataFuture,
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return const Center(child: CircularProgressIndicator());
+              }
+              if (snapshot.hasError || !snapshot.hasData) {
+                return Center(child: Text(snapshot.error.toString()));
+              }
+
+              final data = snapshot.data!;
+              return SingleChildScrollView(
+                padding: EdgeInsets.only(
+                  top: MediaQuery.of(context).padding.top + kToolbarHeight + 12,
+                  left: 12,
+                  right: 12,
+                  bottom: 24,
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _buildMonthHeader(),
+                    const SizedBox(height: 8),
+                    _buildCalendarPager(data.dayNetFlow),
+                    const SizedBox(height: 20),
+                    Text('Monatliche Übersicht', style: Theme.of(context).textTheme.headlineSmall),
+                    const SizedBox(height: 8),
+                    _summaryRow('Einnahmen', data.monthlySnapshot.inflows, AppColors.green),
+                    _summaryRow('Ausgaben', data.monthlySnapshot.outflows, AppColors.red),
+                    _summaryRow(
+                      'Gewinn',
+                      data.monthlySnapshot.profit,
+                      data.monthlySnapshot.profit >= 0 ? AppColors.green : AppColors.red,
+                    ),
+                    const SizedBox(height: 12),
+                    _buildInflowOutflowSwitch(),
+                    const SizedBox(height: 12),
+                    _buildCategoryPieChart(data.monthlySnapshot),
+                    const SizedBox(height: 12),
+                    _buildCategoryList(data.monthlySnapshot),
+                  ],
+                ),
+              );
+            },
+          ),
+          buildLiquidGlassAppBar(context, title: const Text('Calendar')),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMonthHeader() {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        IconButton(
+          onPressed: () => _pageController.previousPage(
+            duration: const Duration(milliseconds: 220),
+            curve: Curves.easeOut,
+          ),
+          icon: const Icon(Icons.chevron_left),
+        ),
+        Text(
+          '${monthName(_selectedMonth.month)} ${_selectedMonth.year}',
+          style: Theme.of(context).textTheme.titleLarge,
+        ),
+        IconButton(
+          onPressed: () => _pageController.nextPage(
+            duration: const Duration(milliseconds: 220),
+            curve: Curves.easeOut,
+          ),
+          icon: const Icon(Icons.chevron_right),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCalendarPager(Map<int, double> dayNetFlow) {
+    return SizedBox(
+      height: 420,
+      child: PageView.builder(
+        controller: _pageController,
+        onPageChanged: (index) {
+          final diff = index - _initialPage;
+          _setMonth(DateTime(DateTime.now().year, DateTime.now().month + diff));
+        },
+        itemBuilder: (context, index) {
+          final diff = index - _initialPage;
+          final month = DateTime(DateTime.now().year, DateTime.now().month + diff);
+          final monthMap = month.year == _selectedMonth.year && month.month == _selectedMonth.month
+              ? dayNetFlow
+              : const <int, double>{};
+          return _MonthGrid(month: month, dayNetFlow: monthMap);
+        },
+      ),
+    );
+  }
+
+  Widget _summaryRow(String label, double value, Color color) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [Text(label), Text(formatCurrency(value), style: TextStyle(color: color, fontWeight: FontWeight.bold))],
+      ),
+    );
+  }
+
+  Widget _buildInflowOutflowSwitch() {
+    return Container(
+      decoration: BoxDecoration(
+        color: Theme.of(context).cardColor,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: GestureDetector(
+              onTap: () => setState(() {
+                _showInflows = true;
+                _showAllCategories = false;
+              }),
+              child: Container(
+                padding: const EdgeInsets.symmetric(vertical: 12),
+                decoration: BoxDecoration(
+                  color: _showInflows ? AppColors.green.withValues(alpha: 0.2) : Colors.transparent,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Center(
+                  child: Text(
+                    'Einnahmen',
+                    style: TextStyle(
+                      color: _showInflows ? AppColors.green : Theme.of(context).textTheme.bodyLarge?.color,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          Expanded(
+            child: GestureDetector(
+              onTap: () => setState(() {
+                _showInflows = false;
+                _showAllCategories = false;
+              }),
+              child: Container(
+                padding: const EdgeInsets.symmetric(vertical: 12),
+                decoration: BoxDecoration(
+                  color: !_showInflows ? AppColors.red.withValues(alpha: 0.2) : Colors.transparent,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Center(
+                  child: Text(
+                    'Ausgaben',
+                    style: TextStyle(
+                      color: !_showInflows ? AppColors.red : Theme.of(context).textTheme.bodyLarge?.color,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  _CategoryDisplayData _categoryData(MonthlyAnalysisSnapshot snapshot) {
+    final categories = _showInflows ? snapshot.categoryInflows : snapshot.categoryOutflows;
+    final totalAmount = categories.values.fold(0.0, (sum, item) => sum + item.abs());
+    final sortedCategories = categories.entries.toList()..sort((a, b) => b.value.abs().compareTo(a.value.abs()));
+
+    final visible = <MapEntry<String, double>>[];
+    bool hasOther = false;
+    double other = 0;
+
+    for (final entry in sortedCategories) {
+      final percentage = totalAmount == 0 ? 0 : (entry.value.abs() / totalAmount) * 100;
+      if (!_showAllCategories && percentage < 1.0) {
+        hasOther = true;
+        other += entry.value;
+      } else {
+        visible.add(entry);
+      }
+    }
+
+    if (hasOther && other != 0) {
+      visible.add(MapEntry('...', other));
+    }
+
+    return _CategoryDisplayData(entries: visible, totalAmount: totalAmount, hasOther: hasOther);
+  }
+
+  Widget _buildCategoryPieChart(MonthlyAnalysisSnapshot snapshot) {
+    final data = _categoryData(snapshot);
+    if (data.entries.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return SizedBox(
+      height: 220,
+      child: PieChart(
+        PieChartData(
+          sectionsSpace: 3,
+          centerSpaceRadius: 40,
+          startDegreeOffset: -90,
+          sections: List.generate(data.entries.length, (index) {
+            final entry = data.entries[index];
+            final ratio = data.totalAmount == 0 ? 0.0 : entry.value.abs() / data.totalAmount;
+            return PieChartSectionData(
+              value: entry.value.abs(),
+              color: chartColors[index % chartColors.length],
+              radius: 84,
+              title: ratio >= 0.08 ? '${(ratio * 100).toStringAsFixed(0)}%' : '',
+              titleStyle: const TextStyle(fontWeight: FontWeight.w600, fontSize: 11),
+            );
+          }),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCategoryList(MonthlyAnalysisSnapshot snapshot) {
+    final categories = _showInflows ? snapshot.categoryInflows : snapshot.categoryOutflows;
+    if (categories.isEmpty) {
+      return const Center(child: Text('Keine Daten für diese Kategorie verfügbar.'));
+    }
+
+    final data = _categoryData(snapshot);
+    final widgets = <Widget>[];
+
+    for (var i = 0; i < data.entries.length; i++) {
+      final entry = data.entries[i];
+      final percentage = data.totalAmount == 0 ? 0 : (entry.value.abs() / data.totalAmount) * 100;
+      widgets.add(
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Expanded(
+                child: Row(
+                  children: [
+                    Container(
+                      width: 10,
+                      height: 10,
+                      decoration: BoxDecoration(color: chartColors[i % chartColors.length], shape: BoxShape.circle),
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(child: Text(entry.key)),
+                  ],
+                ),
+              ),
+              Row(
+                children: [
+                  Text(formatCurrency(entry.value)),
+                  const SizedBox(width: 8),
+                  Text('${percentage.toStringAsFixed(1)}%', style: TextStyle(color: Theme.of(context).hintColor)),
+                ],
+              )
+            ],
+          ),
+        ),
+      );
+    }
+
+    if (data.hasOther && !_showAllCategories) {
+      widgets.add(TextButton(onPressed: () => setState(() => _showAllCategories = true), child: const Text('Alle anzeigen')));
+    } else if (!data.hasOther && _showAllCategories) {
+      widgets.add(TextButton(onPressed: () => setState(() => _showAllCategories = false), child: const Text('Weniger anzeigen')));
+    }
+
+    return Column(children: widgets);
+  }
+}
+
+class _CalendarScreenData {
+  final Map<int, double> dayNetFlow;
+  final MonthlyAnalysisSnapshot monthlySnapshot;
+
+  const _CalendarScreenData({required this.dayNetFlow, required this.monthlySnapshot});
+}
+
+class _CategoryDisplayData {
+  final List<MapEntry<String, double>> entries;
+  final double totalAmount;
+  final bool hasOther;
+
+  const _CategoryDisplayData({required this.entries, required this.totalAmount, required this.hasOther});
+}
+
+class _MonthGrid extends StatelessWidget {
+  final DateTime month;
+  final Map<int, double> dayNetFlow;
+
+  const _MonthGrid({required this.month, required this.dayNetFlow});
+
+  @override
+  Widget build(BuildContext context) {
+    final firstDayOfMonth = DateTime(month.year, month.month, 1);
+    final firstWeekdayOffset = (firstDayOfMonth.weekday + 6) % 7;
+    final gridStart = firstDayOfMonth.subtract(Duration(days: firstWeekdayOffset));
+
+    const weekdayLabels = ['MO.', 'DI.', 'MI.', 'DO.', 'FR.', 'SA.', 'SO.'];
+
+    return Column(
+      children: [
+        Row(
+          children: List.generate(7, (i) {
+            final isSunday = i == 6;
+            return Expanded(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 4),
+                child: Text(
+                  weekdayLabels[i],
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    fontWeight: FontWeight.w600,
+                    color: isSunday ? AppColors.red : Theme.of(context).textTheme.bodyLarge?.color,
+                  ),
+                ),
+              ),
+            );
+          }),
+        ),
+        const Divider(height: 1),
+        Expanded(
+          child: GridView.builder(
+            physics: const NeverScrollableScrollPhysics(),
+            itemCount: 42,
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 7),
+            itemBuilder: (context, index) {
+              final date = gridStart.add(Duration(days: index));
+              final isCurrentMonth = date.month == month.month;
+              final dateInt = date.year * 10000 + date.month * 100 + date.day;
+              final net = dayNetFlow[dateInt];
+              final color = net == null
+                  ? Theme.of(context).hintColor
+                  : (net >= 0 ? AppColors.green : AppColors.red);
+
+              return Container(
+                decoration: BoxDecoration(border: Border.all(color: Theme.of(context).dividerColor.withValues(alpha: 0.25))),
+                padding: const EdgeInsets.all(4),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      '${date.day}',
+                      style: TextStyle(
+                        fontWeight: FontWeight.w700,
+                        color: isCurrentMonth ? Theme.of(context).textTheme.bodyLarge?.color : Theme.of(context).hintColor,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    if (net != null)
+                      Text(
+                        formatCurrency(net),
+                        style: TextStyle(fontSize: 12, color: isCurrentMonth ? color : color.withValues(alpha: 0.45), fontWeight: FontWeight.w600),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                  ],
+                ),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+String monthName(int month) {
+  const names = [
+    'Januar',
+    'Februar',
+    'März',
+    'April',
+    'Mai',
+    'Juni',
+    'Juli',
+    'August',
+    'September',
+    'Oktober',
+    'November',
+    'Dezember',
+  ];
+  return names[(month - 1).clamp(0, 11)];
+}

--- a/lib/widgets/more_pane.dart
+++ b/lib/widgets/more_pane.dart
@@ -6,6 +6,7 @@ import 'package:xfin/screens/assets_screen.dart';
 import 'package:xfin/screens/standing_orders_screen.dart';
 import 'package:xfin/screens/trades_screen.dart';
 import 'package:xfin/screens/transfers_screen.dart';
+import 'package:xfin/screens/calendar_screen.dart';
 
 import 'liquid_glass_widgets.dart';
 
@@ -66,6 +67,12 @@ Future<void> showMorePane({
       icon: Icons.receipt_long,
       onTap: () =>
           Navigator.of(context).push(_noAnimRoute(const TransfersScreen())),
+    ),
+    _PaneItem(
+      label: 'Calendar',
+      icon: Icons.calendar_month,
+      onTap: () =>
+          Navigator.of(context).push(_noAnimRoute(const CalendarScreen())),
     ),
   ];
 

--- a/test/database/daos/analysis_dao_test.dart
+++ b/test/database/daos/analysis_dao_test.dart
@@ -479,4 +479,68 @@ void main() {
           expect(spots.first.y, 150.0);
         });
   });
+
+  group('AnalysisDao - calendar helpers', () {
+    setUp(() async {
+      await db.into(db.accounts).insert(AccountsCompanion.insert(
+            name: 'Cash2',
+            type: AccountTypes.cash,
+          ));
+      await db.into(db.assets).insert(AssetsCompanion.insert(
+            name: 'AST2',
+            type: AssetTypes.stock,
+            tickerSymbol: 'AST2',
+          ));
+
+      await db.into(db.bookings).insert(BookingsCompanion.insert(
+            date: 20240210,
+            accountId: 1,
+            category: 'Salary',
+            shares: 100,
+            value: 100,
+          ));
+      await db.into(db.bookings).insert(BookingsCompanion.insert(
+            date: 20240210,
+            accountId: 1,
+            category: 'Food',
+            shares: -20,
+            value: -20,
+          ));
+      await db.into(db.trades).insert(TradesCompanion.insert(
+            datetime: 20240210120000,
+            assetId: 2,
+            type: TradeTypes.sell,
+            sourceAccountValueDelta: 30,
+            targetAccountValueDelta: -25,
+            shares: 1,
+            costBasis: 1,
+            sourceAccountId: 1,
+            targetAccountId: 1,
+            profitAndLoss: const Value(10),
+            fee: const Value(2),
+            tax: const Value(1),
+          ));
+    });
+
+    test('getDailyNetFlowInRange aggregates bookings and trade account deltas by day', () async {
+      final flow = await analysisDao.getDailyNetFlowInRange(
+        start: DateTime(2024, 2, 1),
+        end: DateTime(2024, 2, 29),
+      );
+
+      expect(flow[20240210], closeTo(85, 1e-9));
+    });
+
+    test('getMonthlyAnalysisSnapshot combines month totals and categories', () async {
+      final snapshot = await analysisDao.getMonthlyAnalysisSnapshot(DateTime(2024, 2, 10));
+
+      expect(snapshot.inflows, closeTo(110, 1e-9));
+      expect(snapshot.outflows, closeTo(-23, 1e-9));
+      expect(snapshot.profit, closeTo(87, 1e-9));
+      expect(snapshot.categoryInflows['Salary'], closeTo(100, 1e-9));
+      expect(snapshot.categoryInflows['Profit aus Trades'], closeTo(10, 1e-9));
+      expect(snapshot.categoryOutflows['Food'], closeTo(-20, 1e-9));
+    });
+  });
+
 }

--- a/test/database/daos/assets_dao_test.dart
+++ b/test/database/daos/assets_dao_test.dart
@@ -202,6 +202,32 @@ void main() {
       expect(await assetsDao.hasAssetsOnAccounts(assetId), isFalse);
     });
 
+
+    test('setArchived moves asset between active and archived streams', () async {
+      final id = await assetsDao.insert(AssetsCompanion.insert(
+        name: 'Archivable Asset',
+        type: AssetTypes.stock,
+        tickerSymbol: 'ARCH',
+      ));
+
+      expect((await assetsDao.watchAllAssets().first).map((e) => e.id),
+          contains(id));
+      expect((await assetsDao.watchArchivedAssets().first).map((e) => e.id),
+          isNot(contains(id)));
+
+      await assetsDao.setArchived(id, true);
+
+      expect((await assetsDao.watchAllAssets().first).map((e) => e.id),
+          isNot(contains(id)));
+      expect((await assetsDao.watchArchivedAssets().first).map((e) => e.id),
+          contains(id));
+
+      await assetsDao.setArchived(id, false);
+
+      expect((await assetsDao.watchAllAssets().first).map((e) => e.id),
+          contains(id));
+    });
+
     group('getAssetAnalysisDetails', () {
       late int assetId;
       late int cashId;

--- a/test/screens/analysis_screen_test.dart
+++ b/test/screens/analysis_screen_test.dart
@@ -300,6 +300,18 @@ void main() {
       });
     });
 
+
+    testWidgets('renders category pie chart for current mode', (tester) async {
+      await tester.runAsync(() async {
+        await pumpWidget(tester);
+        await tester.pumpAndSettle();
+
+        expect(find.byType(PieChart), findsOneWidget);
+
+        await tester.pumpWidget(Container());
+      });
+    });
+
     testWidgets(
         'category list collapses small categories into "..." and toggles show all',
         (tester) async {

--- a/test/screens/assets_screen_test.dart
+++ b/test/screens/assets_screen_test.dart
@@ -107,6 +107,55 @@ void main() {
         await tester.pumpAndSettle();
       }));
 
+
+  testWidgets('long press referenced zero-value asset offers archive and can unarchive', (tester) => tester.runAsync(() async {
+        final l10n = await pumpWidget(tester);
+        await db.into(db.assets).insert(AssetsCompanion.insert(
+              name: 'RefAsset',
+              type: AssetTypes.stock,
+              tickerSymbol: 'REF',
+              value: const Value(0),
+            ));
+        final accountId = await db.into(db.accounts).insert(AccountsCompanion.insert(
+              name: 'A1',
+              type: AccountTypes.portfolio,
+            ));
+        await db.into(db.assetsOnAccounts).insert(AssetsOnAccountsCompanion.insert(
+              accountId: accountId,
+              assetId: 3,
+              shares: const Value(0),
+              value: const Value(0),
+            ));
+
+        await tester.pumpAndSettle();
+
+        final center = tester.getCenter(find.text('RefAsset'));
+        final gesture = await tester.startGesture(center);
+        await tester.pump();
+        await Future.delayed(kLongPressTimeout);
+        await gesture.up();
+        await tester.pumpAndSettle();
+
+        expect(find.text(l10n.archive), findsOneWidget);
+        await tester.tap(find.text(l10n.archive));
+        await tester.pumpAndSettle();
+
+        expect(find.text('RefAsset'), findsNothing);
+        expect(find.text('Archived Assets'), findsOneWidget);
+
+        await tester.tap(find.text('Archived Assets'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('RefAsset'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Confirm'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('RefAsset'), findsOneWidget);
+
+        await tester.pumpWidget(Container());
+        await tester.pumpAndSettle();
+      }));
+
   testWidgets('long press protected asset shows cannot-delete dialog', (tester) => tester.runAsync(() async {
         final l10n = await pumpWidget(tester);
         await tester.pumpAndSettle();

--- a/test/screens/calendar_screen_test.dart
+++ b/test/screens/calendar_screen_test.dart
@@ -1,0 +1,112 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:xfin/database/app_database.dart';
+import 'package:xfin/database/tables.dart';
+import 'package:xfin/l10n/app_localizations.dart';
+import 'package:xfin/providers/database_provider.dart';
+import 'package:xfin/screens/calendar_screen.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppDatabase db;
+
+  Future<void> pumpCalendar(WidgetTester tester) async {
+    await tester.pumpWidget(
+      ChangeNotifierProvider<DatabaseProvider>.value(
+        value: DatabaseProvider.instance,
+        child: const MaterialApp(
+          localizationsDelegates: [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: CalendarScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  setUp(() async {
+    db = AppDatabase(NativeDatabase.memory());
+    DatabaseProvider.instance.initialize(db);
+
+    await db.into(db.assets).insert(AssetsCompanion.insert(
+          name: 'EUR',
+          type: AssetTypes.fiat,
+          tickerSymbol: 'EUR',
+        ));
+
+    final accountId = await db.into(db.accounts).insert(AccountsCompanion.insert(
+          name: 'Cash',
+          type: AccountTypes.cash,
+        ));
+
+    final now = DateTime.now();
+    final currentDateInt = now.year * 10000 + now.month * 100 + now.day;
+    final currentDatetimeInt = currentDateInt * 1000000 + 120000;
+
+    await db.into(db.bookings).insert(BookingsCompanion.insert(
+          date: currentDateInt,
+          accountId: accountId,
+          category: 'Salary',
+          shares: 100,
+          value: 100,
+        ));
+    await db.into(db.bookings).insert(BookingsCompanion.insert(
+          date: currentDateInt,
+          accountId: accountId,
+          category: 'Rent',
+          shares: -40,
+          value: -40,
+        ));
+    await db.into(db.trades).insert(TradesCompanion.insert(
+          datetime: currentDatetimeInt,
+          type: TradeTypes.sell,
+          sourceAccountId: accountId,
+          targetAccountId: accountId,
+          assetId: 1,
+          shares: 1,
+          costBasis: 1,
+          sourceAccountValueDelta: 20,
+          targetAccountValueDelta: -18,
+          fee: const Value(1),
+          tax: const Value(0.5),
+          profitAndLoss: const Value(5),
+        ));
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  testWidgets('renders calendar screen with grid and monthly section', (tester) async {
+    await pumpCalendar(tester);
+
+    expect(find.text('Calendar'), findsOneWidget);
+    expect(find.text('Monatliche Übersicht'), findsOneWidget);
+    expect(find.text('Einnahmen'), findsAtLeastNWidgets(1));
+    expect(find.text('Ausgaben'), findsAtLeastNWidgets(1));
+    expect(find.byType(PageView), findsOneWidget);
+  });
+
+  testWidgets('shows pie chart and category list and toggles outflow view', (tester) async {
+    await pumpCalendar(tester);
+
+    expect(find.byType(PieChart), findsOneWidget);
+    expect(find.text('Salary'), findsOneWidget);
+
+    await tester.tap(find.text('Ausgaben').first);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Rent'), findsOneWidget);
+  });
+}

--- a/test/widget/more_pane_test.dart
+++ b/test/widget/more_pane_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xfin/l10n/app_localizations.dart';
+import 'package:xfin/widgets/more_pane.dart';
+
+void main() {
+  testWidgets('more pane shows calendar item', (tester) async {
+    final navBarVisible = ValueNotifier<bool>(true);
+    final navKey = GlobalKey();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: const [
+          AppLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => Center(
+              child: ElevatedButton(
+                onPressed: () => showMorePane(
+                  context: context,
+                  navBarKey: navKey,
+                  navBarVisible: navBarVisible,
+                ),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Calendar'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
### Motivation
- Provide a visual link between category lists and pie charts on the Analysis screen so users can quickly map list items to chart segments. 
- Add a calendar-first UX (Calendar Screen) that shows per-day net flows and a month-scoped analysis view to allow month-focused filtering and exploration. 
- Bring asset archiving parity with accounts so assets can be archived/unarchived and archived assets are visible and manageable in the UI.

### Description
- Analysis screen: insert a PieChart between the Einnahmen/Ausgaben toggle and the category list and add small colored circle indicators in each category row that match the pie segment colors for visual linkage; keep existing aggregation/toggle behaviour and the "Alle anzeigen / Weniger anzeigen" flow. (lib/screens/analysis_screen.dart)
- Calendar screen: new `CalendarScreen` with Liquid-Glass app bar, swipeable month navigation (`PageView`), month grid (6x7, Mo–So) that shows per-day net flow (bookings + trade source/target deltas), and a month summary section with the same inflow/outflow/pie/list controls filtered to the selected month. (lib/screens/calendar_screen.dart)
- Analysis DAO: added `getDailyNetFlowInRange` and `getMonthlyAnalysisSnapshot` helpers to aggregate per-day net-flow and to provide reusable monthly totals + category maps used by the calendar and analysis UI. (lib/database/daos/analysis_dao.dart)
- Assets DAO & UI: added `setArchived`, `watchArchivedAssets` and adjusted `watchAllAssets` to exclude archived items; updated Assets screen to show archived assets in an expandable section and to support archiving/unarchiving assets (mirrors account behavior). Long-press dialog now offers Archive when deletion is prohibited but the asset value is zero. (lib/database/daos/assets_dao.dart, lib/screens/assets_screen.dart)
- More pane: added a sixth item "Calendar" with calendar icon and navigation to the new `CalendarScreen`. (lib/widgets/more_pane.dart)
- Tests: added/updated widget and DAO tests covering the new calendar screen, more pane, analysis pie-chart rendering, assets archive flow, and the new DAO helpers. New/modified tests include `test/screens/calendar_screen_test.dart`, `test/widget/more_pane_test.dart`, updates to `test/screens/analysis_screen_test.dart`, `test/screens/assets_screen_test.dart`, `test/database/daos/analysis_dao_test.dart`, and `test/database/daos/assets_dao_test.dart`.

### Testing
- Added/updated automated tests for all touched areas (UI + DAO) but could not run Flutter/Dart tests in this environment because the SDK binaries are not available; the following test files were added/changed: `test/screens/calendar_screen_test.dart`, `test/widget/more_pane_test.dart`, `test/screens/analysis_screen_test.dart`, `test/screens/assets_screen_test.dart`, `test/database/daos/analysis_dao_test.dart`, and `test/database/daos/assets_dao_test.dart` (created/updated). 
- Performed repository checks and diffs to verify changes were applied (`git diff --stat` / diff consistency). 
- Attempted to run formatting/testing (`dart format` / `flutter`), and a Playwright screenshot of a running app, but these steps failed due to missing SDK / no running app instance; therefore all new tests were added but not executed here. 

If you want, I can run the test suite and format the code once a machine with Flutter/Dart is available or provide a CI job snippet to run `dart format` and `flutter test` in your pipeline.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2ecf4f04c8332ad7f63d22b60c4ee)